### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = ""

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # python-study
+[![Run on Repl.it](https://repl.it/badge/github/shibas11/python-study)](https://repl.it/github/shibas11/python-study)
 
 ## 개발환경 설정
 - `https://www.python.org/downloads/`에서 dpkg 다운로드 및 설치


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).